### PR TITLE
starting workflow that will automatically deploy containers

### DIFF
--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -32,8 +32,11 @@ jobs:
 
           # registry organization
           registry: quay.io/buildsi
+
+          # commits from the previous merge-commits action
+          commits: ${{join(steps.commits.outputs.commits, '\n')}}
         run: |
-           printf "${{ steps.commits.outputs.commits }}\n"
+            printf "${{ env.commits }}\n"
             #git fetch
             #printf "Looking for changes in tester ${{ matrix.tester }}\n"
             #cd docker/${{ matrix.tester }}

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -44,7 +44,11 @@ jobs:
             cd docker/${{ matrix.tester }}
             versions="${{ matrix.tester }}_versions"
             newbuilds=no
-            for commit in $("${{ env.commits }}"); do
+
+            # We will be splitting the commits by space
+            IFS=' '
+            read -ra COMMITS <<< "${{ env.commits }}";
+            for commit in "${COMMITS[@]}"; do
                 printf "Looking for changed containers with commit $commit\n"
                 for dockerfile in $(git diff --name-only $commit .); do
                     printf "Found changed Dockerfile ${dockerfile}\n"

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -42,9 +42,9 @@ jobs:
             git fetch
             printf "Looking for changes in tester ${{ matrix.tester }}\n"
             cd docker/${{ matrix.tester }}
+            versions="${{ matrix.tester }}_versions"
             for commit in "${{ env.commits }}"; do
                 for dockerfile in $(git diff --name-only $commit .); do
-                    versions="${{ matrix.tester }}_versions"
                     filename=$(basename $dockerfile)
                     for version in ${!versions}; do                  
                         container=${{ env.registry }}/${{ matrix.tester }}:${version}
@@ -54,8 +54,10 @@ jobs:
                 done
             done
 
+            docker images
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            versions="${{ matrix.tester }}_versions"
             for version in ${!versions}; do
-                docker push quay.io/buildsi/${{ matrix.tester }}:${version}
+                container=${{ env.registry }}/${{ matrix.tester }}:${version}
+                printf "Deploying ${container}\n"
+                docker push ${container}
             done

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -1,8 +1,6 @@
 name: "Deploy Base Containers"
 
 on:
-  # Just for development for now
-  pull_request: []
   push:
     branches:
       - main

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -37,16 +37,17 @@ jobs:
           # commits from the previous merge-commits action
           commits: ${{steps.get_commits.outputs.commits}}
         run: |
-            printf "${{ env.commits }}\n"
-            #git fetch
-            #printf "Looking for changes in tester ${{ matrix.tester }}\n"
-            #cd docker/${{ matrix.tester }}
-            #for dockerfile in $(git diff --name-only origin/main HEAD .); do
-            #    versions="${{ matrix.tester }}_versions"
-            #    filename=$(basename $dockerfile)
-            #    for version in ${!versions}; do                  
-            #        container=${{ env.registry }}/${{ matrix.tester }}:${version}
-            #        printf "Building ${dockerfile} with version ${version} to container ${container}\n"  
-            #        docker build -f ${filename} --build-arg LIBRARY_VERSION=${version} -t ${container} .
-            #    done
-            #done
+            git fetch
+            printf "Looking for changes in tester ${{ matrix.tester }}\n"
+            cd docker/${{ matrix.tester }}
+            for commit in "${{ env.commits }}"; do
+                for dockerfile in $(git diff --name-only $commit .); do
+                    versions="${{ matrix.tester }}_versions"
+                    filename=$(basename $dockerfile)
+                    for version in ${!versions}; do                  
+                        container=${{ env.registry }}/${{ matrix.tester }}:${version}
+                        printf "Building ${dockerfile} with version ${version} to container ${container}\n"  
+                        docker build -f ${filename} --build-arg LIBRARY_VERSION=${version} -t ${container} .
+                    done
+                 done
+             done

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Run Merge Commits
         uses: autamus/merge-commits@test/action
         id: get_commits
-      - name:
+
+      - name: Build Production Containers
         env:
           # Space separated list of versions to build for a named tester
           libabigail_versions: "1.8.2"
@@ -36,6 +37,7 @@ jobs:
 
           # commits from the previous merge-commits action
           commits: ${{steps.get_commits.outputs.commits}}
+
         run: |
             git fetch
             printf "Looking for changes in tester ${{ matrix.tester }}\n"
@@ -51,3 +53,8 @@ jobs:
                     done
                  done
              done
+             
+      - name: Deploy
+        run: |
+            echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            docker push quay.io/buildsi/${{ matrix.tester }}

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -1,0 +1,48 @@
+name: "Deploy Base Containers"
+
+on:
+  # Just for development for now
+  pull_request: []
+  push:
+    branches:
+      - main
+ 
+jobs:
+  find-commits:
+    runs-on: ubuntu-latest
+    strategy:
+      # Add new testers here. Each tester needs a subfolder in docker, and a
+      # Dockerfile that accepts a LIBRARY_VERSION variable
+      matrix:
+        tester: ["libabigail"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        id: commits
+        with:
+          fetch-depth: '0'
+
+      # This will set output of space separated commits to the job step
+      - name: Run Merge Commits
+        uses: autamus/merge-commits@1857889f6a3b023adbc766a67142c245354f4a87
+      - name:
+        env:
+          # Space separated list of versions to build for a named tester
+          libabigail_versions: "1.8.2"
+
+          # registry organization
+          registry: quay.io/buildsi
+        run: |
+            printf "${{ steps.commits.outputs.commits }}\n"
+            #git fetch
+            #printf "Looking for changes in tester ${{ matrix.tester }}\n"
+            #cd docker/${{ matrix.tester }}
+            #for dockerfile in $(git diff --name-only origin/main HEAD .); do
+            #    versions="${{ matrix.tester }}_versions"
+            #    filename=$(basename $dockerfile)
+            #    for version in ${!versions}; do                  
+            #        container=${{ env.registry }}/${{ matrix.tester }}:${version}
+            #        printf "Building ${dockerfile} with version ${version} to container ${container}\n"  
+            #        docker build -f ${filename} --build-arg LIBRARY_VERSION=${version} -t ${container} .
+            #    done
+            #done

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -43,8 +43,12 @@ jobs:
             printf "Looking for changes in tester ${{ matrix.tester }}\n"
             cd docker/${{ matrix.tester }}
             versions="${{ matrix.tester }}_versions"
+            newbuilds=no
             for commit in "${{ env.commits }}"; do
+                printf "Looking for changed containers with commit $commit\n"
                 for dockerfile in $(git diff --name-only $commit .); do
+                    printf "Found changed Dockerfile ${dockerfile}\n"
+                    newbuilds=yes
                     filename=$(basename $dockerfile)
                     for version in ${!versions}; do                  
                         container=${{ env.registry }}/${{ matrix.tester }}:${version}
@@ -54,10 +58,14 @@ jobs:
                 done
             done
 
-            docker images
-            echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            for version in ${!versions}; do
-                container=${{ env.registry }}/${{ matrix.tester }}:${version}
-                printf "Deploying ${container}\n"
-                docker push ${container}
-            done
+            if [ "${newbuilds}" == "yes" ]; then
+                docker images
+                echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+                for version in ${!versions}; do
+                    container=${{ env.registry }}/${{ matrix.tester }}:${version}
+                    printf "Deploying ${container}\n"
+                    docker push ${container}
+                done
+            else
+                printf "No new builds\n"
+            fi

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -25,6 +25,7 @@ jobs:
       # This will set output of space separated commits to the job step
       - name: Run Merge Commits
         uses: autamus/merge-commits@test/action
+        id: get_commits
       - name:
         env:
           # Space separated list of versions to build for a named tester
@@ -34,7 +35,7 @@ jobs:
           registry: quay.io/buildsi
 
           # commits from the previous merge-commits action
-          commits: ${{join(steps.commits.outputs.commits, '\n')}}
+          commits: ${{steps.get_commits.outputs.commits}}
         run: |
             printf "${{ env.commits }}\n"
             #git fetch

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -33,7 +33,7 @@ jobs:
           # registry organization
           registry: quay.io/buildsi
         run: |
-            printf "${{ steps.commits.outputs.commits }}\n"
+           printf "${{ steps.commits.outputs.commits }}\n"
             #git fetch
             #printf "Looking for changes in tester ${{ matrix.tester }}\n"
             #cd docker/${{ matrix.tester }}

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -44,7 +44,7 @@ jobs:
             cd docker/${{ matrix.tester }}
             versions="${{ matrix.tester }}_versions"
             newbuilds=no
-            for commit in "${{ env.commits }}"; do
+            for commit in $("${{ env.commits }}"); do
                 printf "Looking for changed containers with commit $commit\n"
                 for dockerfile in $(git diff --name-only $commit .); do
                     printf "Found changed Dockerfile ${dockerfile}\n"

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: autamus/merge-commits@test/action
         id: get_commits
 
-      - name: Build Production Containers
+      - name: Build and Deploy
         env:
           # Space separated list of versions to build for a named tester
           libabigail_versions: "1.8.2"
@@ -51,10 +51,11 @@ jobs:
                         printf "Building ${dockerfile} with version ${version} to container ${container}\n"  
                         docker build -f ${filename} --build-arg LIBRARY_VERSION=${version} -t ${container} .
                     done
-                 done
-             done
-             
-      - name: Deploy
-        run: |
+                done
+            done
+
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            docker push quay.io/buildsi/${{ matrix.tester }}
+            versions="${{ matrix.tester }}_versions"
+            for version in ${!versions}; do
+                docker push quay.io/buildsi/${{ matrix.tester }}:${version}
+            done

--- a/.github/workflows/deploy-containers.yaml
+++ b/.github/workflows/deploy-containers.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # This will set output of space separated commits to the job step
       - name: Run Merge Commits
-        uses: autamus/merge-commits@1857889f6a3b023adbc766a67142c245354f4a87
+        uses: autamus/merge-commits@test/action
       - name:
         env:
           # Space separated list of versions to build for a named tester

--- a/README.md
+++ b/README.md
@@ -15,6 +15,36 @@ examples, and eventually will likely have multiple. The approach we take is the 
  - [docker](docker): includes `Dockerfile`s, one per testing base, that will be deployed to [quay.io/buildsi](https://quay.io/organization/buildsi).
  - [templates](templates): includes container build templates that can start with an autamus base container for some package, and then add layers for the testing software (e.g., libabigail and eventually smeagle). I might also test just installing directly from spack, not decided yet.
 
+## Container Testing Bases
+
+The folder [docker](docker) has subfolders for one or more testing bases, where a testing
+base is a library like libabigail or Smeagle that can be pre-built into a container
+and then used quickly. This means that to add a new testing base you should:
+
+1. Create a subdirectory that matches the name of the tester, e.g [docker/libabigail](docker/libabigail)
+2. Create a Dockerfile in this folder with an ubuntu 18.04 or 20.04 base that installs the testing framework. The executables that the tester needs should be on the path. The Dockerfile should accept a `LIBRRARY_VERSION` build argument that will set one or more versions to build.
+3. In each of [deploy-containers.yaml](.github/workflows/deploy-containers.yaml) and [build-containers.yaml](.github/workflows/build-containers.yaml) add the name of the tester to testers, and add an environment variable `<tester>_versions` that includes a string separated list of versions.
+
+```yaml
+strategy:
+  # Add new testers here. Each tester needs a subfolder in docker, and a
+  # Dockerfile that accepts a LIBRARY_VERSION variable
+  matrix:
+    tester: ["libabigail"]
+steps:
+  - name: Checkout
+    uses: actions/checkout@v2        
+  - name: Test Building Changes
+    env:
+      # Space separated list of versions to build for a named tester
+      libabigail_versions: "1.8.2"
+```
+
+In the above, you see we've added "libabigail" as a tester, and a libabigail_version
+variable to define our versions. This needs to be done with both workflow files. From
+these bases, we will also have a means to test using these containers (not developed yet).
+
+
 ## Development Notes
 
 ### How will it work?
@@ -48,7 +78,7 @@ on the autamus registry, which means that:
  
 We could install with spack natively, but we will save a lot of time using
 pre-built layers. Note that the scripts to make this happen aren't developed
-yet - I need to create the base containers first.
+yet - we just have the base containers.
 
  
 ### Bolo's Notes

--- a/docker/libabigail/Dockerfile.libabigail
+++ b/docker/libabigail/Dockerfile.libabigail
@@ -19,8 +19,7 @@ RUN apt-get update && apt-get install -y build-essential \
     python3-lxml \
     python3 \
     python3-dev \
-    python3-sphinx \
-    python3-pip
+    python3-sphinx
 
 RUN ldconfig && \ 
     wget http://mirrors.kernel.org/sourceware/libabigail/libabigail-${LIBRARY_VERSION}.tar.gz && \


### PR DESCRIPTION
This workflow will get updated commits, and then again look for changed container bases in docker. There is redundancy in defining the versions for libabigail in the two files, and there isn't much of a way around that because GitHub actions can't easily share files. We can add a check to make sure they are both updated if needed.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>